### PR TITLE
feat: allow specifying the same option multiple times using an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ async function convert() {
   Object of options which you normally pass to the ffmpeg command in the terminal.
   Documentation for individual options can be found at [ffmpeg site](https://ffmpeg.org/ffmpeg.html) in audio and video category.
   For boolean options specify `true` or `false`.
+  If you'd like to specify the same argument multiple times you can do so by providing an array of values. E.g. `{ map: ["0:v", "1:a"] }`
 
 # FAQ
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,13 +30,20 @@ function getTmpPath(prefix = "", suffix = ""): string {
   return join(dir, `${prefix}${id}${suffix}`)
 }
 
-type Options = Record<string, string | number | boolean | null | undefined>
+type Options = Record<string, string | number | boolean | Array<string | null | undefined> | null | undefined>
 
 function getArgs(options: Options): string[] {
   const args: string[] = []
   for (const option in options) {
     const value = options[option]
-    if (value != null && value !== false) {
+    if (Array.isArray(value)) {
+      for (const element of value) {
+        if (element != null) {
+          args.push(`-${option}`)
+          args.push(String(element))
+        }
+      }
+    } else if (value != null && value !== false) {
       args.push(`-${option}`)
       if (typeof value != "boolean") {
         args.push(String(value))


### PR DESCRIPTION
Closes #25. 

I haven't added any test coverage for this, sorry. Based on the current test suite I think it would be hard to do. If you'd like me to add tests I think I'll have to bring in `ffprobe` and `ffprobe-static` as devDependencies.

I have tested this in my own application using `npm link` though, and it's working for my requirements.

A more DRY way of implementing this feature would be to make `value` always an array using a ternary expression, but I think the way I've implemented it makes the intent more obvious when reading the code. If you want me to change it to be more DRY I'm happy to do so.