### PR TITLE
readme: get last frame data in individual frames snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ class ExtractFrames extends Transform {
     done()
   }
 
-  // TODO: Fix not emitting the last frame in a stream
+  _flush(done) {
+    this.push(this.currentData);
+    done();
+  }
 }
 ```
 


### PR DESCRIPTION
I'm not an expert with streams but this looked like the right solution and worked for me.

In my video it definitely emitted the last frame, and it was different than the penultimate one.