### PR TITLE
feat!: pass custom ffmpeg path via argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 
 Node bindings to ffmpeg command, exposing stream based API.
 
-[CHANGELOG](CHANGELOG.md)
-
-**Note:** ffmpeg must be installed and available in `PATH`.
-You can set a custom ffmpeg path via `FFMPEG_PATH` environment variable (default is just `ffmpeg`).
+> [!NOTE]
+> FFmpeg must be installed and available in `PATH`.
+> You can set a custom ffmpeg path via an argument (default is just `ffmpeg`).
 
 ## Examples
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ import { join } from "node:path"
 import { PassThrough } from "node:stream"
 
 const dbg = debug("ffmpeg-stream")
-const { FFMPEG_PATH = "ffmpeg" } = process.env
 const EXIT_CODES = [0, 255]
 
 /**
@@ -100,8 +99,6 @@ function getArgs(options) {
 /**
  * A class which wraps a FFmpeg process.
  *
- * Remember to call {@link Converter.run} to start the conversion.
- *
  * @example
  *
  * ```js
@@ -138,6 +135,18 @@ export class Converter {
    * @private
    */
   killed = false
+
+  /**
+   * Initializes the converter.
+   *
+   * Remember to call {@link Converter.run} to actually start the FFmpeg process.
+   *
+   * @param {string} [ffmpegPath] Path to the FFmpeg executable. (default: `"ffmpeg"`)
+   */
+  constructor(ffmpegPath = "ffmpeg") {
+    /** @private */
+    this.ffmpegPath = ffmpegPath
+  }
 
   /**
    * Defines an FFmpeg input file.
@@ -377,9 +386,9 @@ export class Converter {
 
       const command = this.getSpawnArgs()
       const stdio = this.getStdioArg()
-      dbg(`spawn: ${FFMPEG_PATH} ${command.join(" ")}`)
+      dbg(`spawn: ${this.ffmpegPath} ${command.join(" ")}`)
       dbg(`spawn stdio: ${stdio.join(" ")}`)
-      this.process = spawn(FFMPEG_PATH, command, { stdio })
+      this.process = spawn(this.ffmpegPath, command, { stdio })
       const finished = this.handleProcess()
 
       for (const pipe of this.pipes) {


### PR DESCRIPTION
BREAKING CHANGE: passing ffmpeg path via env var is not supported anymore